### PR TITLE
Remember last scroll position in articles

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -13,7 +13,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/src/main/java/com/pigeoff/rss/adapters/ArticlesAdapter.kt
+++ b/app/src/main/java/com/pigeoff/rss/adapters/ArticlesAdapter.kt
@@ -30,6 +30,7 @@ class ArticlesAdapter(val context: Context,
     var service = (context.applicationContext as RSSApp).getClient()
     var selectedItems = mutableListOf<RSSDbItem>()
 
+    val ITEM_ID_EXTRA: String = "itemidextra"
     val URL_EXTRA: String = "urlextra"
     val AUDIO_EXTRA: String = "audioextra"
     val TITLE_EXTRA: String = "titleextra"
@@ -219,6 +220,7 @@ class ArticlesAdapter(val context: Context,
         } else {
             Intent(context.applicationContext, ReadActivity::class.java);
         }
+        intent.putExtra(ITEM_ID_EXTRA, item.id)
         intent.putExtra(URL_EXTRA, item.link)
         intent.putExtra(AUDIO_EXTRA, item.audio)
         intent.putExtra(TITLE_EXTRA, item.title)

--- a/app/src/main/java/com/pigeoff/rss/adapters/FeedArticlesAdapter.kt
+++ b/app/src/main/java/com/pigeoff/rss/adapters/FeedArticlesAdapter.kt
@@ -26,6 +26,7 @@ class FeedArticlesAdapter(val context: Context,
                           var posts: MutableList<ArticleExtended>,
                           var favicon: String) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
+    val ITEM_ID_EXTRA: String = "itemidextra"
     val URL_EXTRA: String = "urlextra"
     val AUDIO_EXTRA: String = "audioextra"
     val TITLE_EXTRA: String = "titleextra"

--- a/app/src/main/java/com/pigeoff/rss/db/RSSDb.kt
+++ b/app/src/main/java/com/pigeoff/rss/db/RSSDb.kt
@@ -1,9 +1,21 @@
 package com.pigeoff.rss.db
 
 import androidx.room.*
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
-@Database(entities = [RSSDbFeed::class, RSSDbItem::class], version = 1)
+@Database(
+    entities = [RSSDbFeed::class, RSSDbItem::class],
+    version = 2
+)
 abstract class RSSDb : RoomDatabase() {
     abstract fun feedDao(): RSSDbFeedDAO
     abstract fun itemDao(): RSSDbItemDAO
+}
+
+val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE RSSDbItem ADD COLUMN " +
+                "lastScrollYPosition INT NOT NULL DEFAULT 0");
+    }
 }

--- a/app/src/main/java/com/pigeoff/rss/db/RSSDbItem.kt
+++ b/app/src/main/java/com/pigeoff/rss/db/RSSDbItem.kt
@@ -31,5 +31,6 @@ data class RSSDbItem (
     var interesting: Boolean = true,
     var fav: Boolean = false,
     var consulted: Boolean = false,
-    var consultedTime: Long = 0
+    var consultedTime: Long = 0,
+    var lastScrollYPosition: Int = 0
 )

--- a/app/src/main/java/com/pigeoff/rss/db/RSSDbItemDAO.kt
+++ b/app/src/main/java/com/pigeoff/rss/db/RSSDbItemDAO.kt
@@ -4,6 +4,9 @@ import androidx.room.*
 
 @Dao
 interface RSSDbItemDAO {
+    @Query("SELECT * FROM RSSDbItem WHERE id=:id")
+    fun getItemById(id: Int): RSSDbItem
+
     @Query("SELECT * FROM RSSDbItem ORDER BY id DESC")
     fun getAllItems(): MutableList<RSSDbItem>
 

--- a/app/src/main/java/com/pigeoff/rss/services/FeedsService.kt
+++ b/app/src/main/java/com/pigeoff/rss/services/FeedsService.kt
@@ -3,7 +3,10 @@ package com.pigeoff.rss.services
 import android.content.Context
 import androidx.preference.PreferenceManager
 import androidx.room.Room
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.pigeoff.rss.R
+import com.pigeoff.rss.db.MIGRATION_1_2
 import com.pigeoff.rss.db.RSSDb
 import com.pigeoff.rss.db.RSSDbFeed
 import com.pigeoff.rss.db.RSSDbItem
@@ -22,8 +25,10 @@ class FeedsService(context: Context) {
 
     val db: RSSDb = Room.databaseBuilder(
         context.applicationContext,
-        RSSDb::class.java, "rssdb"
-    ).allowMainThreadQueries().build()
+        RSSDb::class.java, "rssdb")
+        .allowMainThreadQueries()
+        .addMigrations(MIGRATION_1_2)
+        .build()
 
     var parser: Parser = Parser.Builder()
         .context(context)

--- a/app/src/main/res/layout/activity_read.xml
+++ b/app/src/main/res/layout/activity_read.xml
@@ -114,25 +114,16 @@
             android:indeterminateTint="@color/colorAccent" />
     </com.google.android.material.appbar.AppBarLayout>
 
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/nestedScrollView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scrollbars="vertical"
+        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
 
-
-
-        <androidx.core.widget.NestedScrollView
+        <WebView
+            android:id="@+id/webView"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="vertical">
-
-
-
-                <WebView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" android:id="@+id/webView"/>
-            </LinearLayout>
-
-
-        </androidx.core.widget.NestedScrollView>
+            android:layout_height="wrap_content"/>
+    </androidx.core.widget.NestedScrollView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## What this PR does...
This PR introduces the necessary changes to remember the last scroll position in articles in the reading list.

## Motivation
After using the app for a bit, I realized that when I closed an article in my reading list and then reopened it, the last scroll position was lost. I can imagine users often don't read the entire article at once, since this can take some time, especially for longer articles. Therefore, it might be useful that, e.g., when opening an article you started two days before, the position where you left off is recovered so that you don't have to skim through the article trying to remember where you stopped reading.

## Main changes
- Last Y scroll position is saved in the database in the `RSSDbItem`.
- Saved Y scroll position is loaded if available when opening an article from the reading list. Then, a smooth scroll to that position is performed.
- The layout for Activity Read has been slightly simplified (removed unnecessary `LinearLayout` inside `NestedScrollView`).
- Visibility of the progress bar in `ReadActivity` has been changed from `GONE` to `INVISIBLE` to avoid content slightly "jumping" up when the bar is gone.

## Additional details
Since this is my first contribution to the project, I've tried to introduce as few changes as possible. Needless to say, I'm open to any changes :) And thanks for this useful app!